### PR TITLE
[Add Correlations] Fixed problem for rebinned data

### DIFF
--- a/DreamFunction/DreamCF.h
+++ b/DreamFunction/DreamCF.h
@@ -16,10 +16,10 @@ class DreamCF {
  public:
   DreamCF();
   virtual ~DreamCF();
-  void SetPairs(DreamPair* pairOne, DreamPair* pairTwo, const bool& CORRECT_ADDITON=false) {
+  void SetPairs(DreamPair* pairOne, DreamPair* pairTwo, const bool& direct_sum=false) {
     fPairOne = pairOne;
     fPairTwo = pairTwo;
-    DirectSum = CORRECT_ADDITON;
+    fDirectSum = direct_sum;
   }
   ;
   void SetPairsBBar(DreamPair* pairOne) {
@@ -32,6 +32,8 @@ class DreamCF {
   void LoopCorrelations(std::vector<DreamDist*> Pair, const char* name);
   void WriteOutput(const char* name);
   void WriteOutput(TFile* output, bool closeFile);
+  //required of rebinned data!
+  TH1F* AddCF(DreamDist* DD1, DreamDist* DD2, const char* name);
   TH1F* AddCF(TH1F* CF1, TH1F* CF2, const char* name);
   static TGraphAsymmErrors* AddCF(TH1F* histSum, std::vector<DreamPair*> pairs, const char* name);
   static TH1F* ConvertToOtherUnit(TH1F* HistCF, int Scale, const char* name);
@@ -70,7 +72,7 @@ class DreamCF {
   //weighted mean based on the errors of the correlations (WRONG)
   //the above option has to be kept the default one for compatibility reasons
   //in any future analysis this HAS TO BE TRUE!!!
-  bool DirectSum;
+  bool fDirectSum;
 };
 
 #endif /* DREAMCF_H_ */

--- a/DreamFunction/DreamDist.cxx
+++ b/DreamFunction/DreamDist.cxx
@@ -14,9 +14,9 @@ DreamDist::DreamDist()
       fME(nullptr),
       fMEMult(nullptr),
       fCF(nullptr),
-      fGrCF(nullptr) {
-  NormLeft=-1;
-  NormRight=-1;
+      fGrCF(nullptr),
+      fNormLeft(-1),
+      fNormRight(-1) {
 }
 DreamDist::DreamDist(DreamDist* pair, const char* name)
     : fSE(nullptr),
@@ -24,15 +24,15 @@ DreamDist::DreamDist(DreamDist* pair, const char* name)
       fME(nullptr),
       fMEMult(nullptr),
       fCF(nullptr),
-      fGrCF(nullptr) {
+      fGrCF(nullptr),
+      fNormLeft(-1),
+      fNormRight(-1) {
   this->SetSEDist(pair->GetSEDist(), name);
   if (pair->GetSEMultDist())
     this->SetSEMultDist(pair->GetSEMultDist(), name);
   this->SetMEDist(pair->GetMEDist(), name);
   if (pair->GetMEMultDist())
     this->SetMEMultDist(pair->GetMEMultDist(), name);
-  NormLeft=-1;
-  NormRight=-1;
 }
 
 DreamDist::~DreamDist() {
@@ -79,8 +79,8 @@ void DreamDist::Calculate_CF(float normleft, float normright,
     fGrCF = new TGraphAsymmErrors(fCF);
     fGrCF->Set(0);
 
-    NormLeft = normleft;
-    NormRight = normright;
+    fNormLeft = normleft;
+    fNormRight = normright;
     Double_t norm_relK = 0;
     double IntegralSE = fSE->Integral(fSE->FindBin(normleft),
                                       fSE->FindBin(normright));

--- a/DreamFunction/DreamDist.h
+++ b/DreamFunction/DreamDist.h
@@ -51,8 +51,8 @@ class DreamDist {
   TGraphAsymmErrors* GetGrCF() {
     return fGrCF;
   }
-  float GetNormLeft() const{return NormLeft;}
-  float GetNormRight() const{return NormRight;}
+  float GetNormLeft() const{return fNormLeft;}
+  float GetNormRight() const{return fNormRight;}
 
   void WriteOutput(TList *Outlist) {
     Outlist->Add(fSE);
@@ -74,7 +74,7 @@ class DreamDist {
   TH2F* fMEMult;
   TH1F* fCF;
   TGraphAsymmErrors *fGrCF;
-  float NormLeft,NormRight;
+  float fNormLeft,fNormRight;
 
 };
 

--- a/DreamFunction/DreamKayTee.cxx
+++ b/DreamFunction/DreamKayTee.cxx
@@ -28,6 +28,7 @@ DreamKayTee::DreamKayTee(const int imTMult)
     fSum(nullptr),
     fNormleft(0),
     fNormright(0),
+    fDirectSum(0),
     fSEMEReweighting(nullptr),
     fSEMEReweightingMeV(nullptr) {
   fSEkT[0] = nullptr;
@@ -121,7 +122,7 @@ void DreamKayTee::ObtainTheCorrelationFunction(const char* outFolder,
       allCFsOut->Close();
       for (int ikT = 0; ikT < fNKayTeeBins - 1; ++ikT) {
         fSum[ikT] = new DreamCF();
-        fSum[ikT]->SetPairs(fCFPart[0][ikT], fCFPart[1][ikT]);
+        fSum[ikT]->SetPairs(fCFPart[0][ikT], fCFPart[1][ikT], fDirectSum);
         fSum[ikT]->GetCorrelations(pair);
         std::vector<TH1F*> CFs = fSum[ikT]->GetCorrelationFunctions();
         TString outfileName = TString::Format("%s/CFOutput_%s_%s_%s_%u.root",
@@ -241,7 +242,7 @@ void DreamKayTee::ObtainTheCorrelationFunctionAncestors(const char* outFolder,
       allCFsOut->Close();
       for (int ikT = 0; ikT < fNKayTeeBins - 1; ++ikT) {
         fSum[ikT] = new DreamCF();
-        fSum[ikT]->SetPairs(fCFPart[0][ikT], fCFPart[1][ikT]);
+        fSum[ikT]->SetPairs(fCFPart[0][ikT], fCFPart[1][ikT], fDirectSum);
         fSum[ikT]->GetCorrelations(pair);
         std::vector<TH1F*> CFs = fSum[ikT]->GetCorrelationFunctions();
         TString outfileName = TString::Format("%s/CFOutput_%s_%s_%s_%s_%u.root",
@@ -739,7 +740,7 @@ std::vector<DreamCF*> DreamKayTee::GetmTMultBinned(int imT, int Varcount) {
     //pp->Rebin(pp->GetPairFixShifted(0), 20);
     //ApAp->Rebin(ApAp->GetPairFixShifted(0), 20);
 
-    CF_pp->SetPairs(pp,ApAp);
+    CF_pp->SetPairs(pp,ApAp, fDirectSum);
     CF_pp->GetCorrelations();
     CF_pp->WriteOutput(TString::Format("%s/CF_ppVar%u_mTBin_%i_%s.root",gSystem->pwd(),Varcount,
                                        imT,ProjName.Data()));

--- a/DreamFunction/DreamKayTee.h
+++ b/DreamFunction/DreamKayTee.h
@@ -75,6 +75,9 @@ class DreamKayTee {
   void SetMultBins(std::vector<int> multBins) {
     fMultBins = multBins;
   };
+  void SetDirectSum(const bool& direct_sum) {
+    fDirectSum = direct_sum;
+  };
   std::vector<DreamCF*> GetmTMultBinned(int imT, int Varcount);
  private:
   bool fIskT;
@@ -94,6 +97,7 @@ class DreamKayTee {
   DreamCF** fSum;
   float fNormleft;
   float fNormright;
+  bool fDirectSum;
   TH1F* fSEMEReweighting;
   TH1F* fSEMEReweightingMeV;
 };

--- a/GentleKitty/CATSInput.cxx
+++ b/GentleKitty/CATSInput.cxx
@@ -32,7 +32,8 @@ CATSInput::CATSInput()
       fSigma(),
       fCF_pL(nullptr),
       fCF_LL(nullptr),
-      fCF_pXi(nullptr) {
+      fCF_pXi(nullptr),
+      fDirectSum(0) {
   // TODO Auto-generated constructor stub
   TH1::AddDirectory(kFALSE);
   TH2::AddDirectory(kFALSE);
@@ -285,16 +286,16 @@ void CATSInput::ObtainCFs(int rebin, float normleft, float normright) {
       pXi->ReweightMixedEvent(pXi->GetPairRebinned(0), 0.2, 0.9);
       ApAXi->ReweightMixedEvent(ApAXi->GetPairRebinned(0), 0.2, 0.9);
 
-      fCF_pp->SetPairs(pp, ApAp);
+      fCF_pp->SetPairs(pp, ApAp, fDirectSum);
       fCF_pp->GetCorrelations("pp");
 
-      fCF_pL->SetPairs(pL, ApAL);
+      fCF_pL->SetPairs(pL, ApAL, fDirectSum);
       fCF_pL->GetCorrelations("pL");
 
-      fCF_LL->SetPairs(LL, ALAL);
+      fCF_LL->SetPairs(LL, ALAL, fDirectSum);
       fCF_LL->GetCorrelations("LL");
 
-      fCF_pXi->SetPairs(pXi, ApAXi);
+      fCF_pXi->SetPairs(pXi, ApAXi, fDirectSum);
       fCF_pXi->GetCorrelations("pXi");
       fnormalizationLeft = normleft;
       fnormalizationRight = normright;
@@ -358,7 +359,7 @@ DreamCF* CATSInput::ObtainCFSyst(int rebin, const char* name, DreamDist* ppDist,
     }
   }
 
-  outCF->SetPairs(pp, ApAp);
+  outCF->SetPairs(pp, ApAp, fDirectSum);
   outCF->GetCorrelations(name);
   return outCF;
 }

--- a/GentleKitty/CATSInput.h
+++ b/GentleKitty/CATSInput.h
@@ -71,6 +71,11 @@ DreamCF* ObtainCFSystBBar(int rebin, const char* name, DreamDist* pApDist,
   void SetMomentumGami(MomentumGami* gami) {
     fMomGami = gami;
   }
+  //important to set true in all future analyises
+  void SetDirectSum(const bool& direct_sum) {
+    fDirectSum = direct_sum;
+  };
+
  protected:
   ReadDreamFile* fDreamFile;
   float fnormalizationLeft;
@@ -86,6 +91,7 @@ DreamCF* ObtainCFSystBBar(int rebin, const char* name, DreamDist* pApDist,
   TString fNameSigmaFile;
   int fFraction_Res;
   int fFraction_Sig;
+  bool fDirectSum;
   double fUnitConv_Res;
   double fUnitConv_Sig;
   std::vector<TH2F*> fRes;


### PR DESCRIPTION
In addition, in the CATSinput and DreamKeyTee we have a SetDirectSum option, which should be set to TRUE if the user wants to activate the addition of correlation functions using the direct sum method, over the original weighted mean according to errors. 

There is one remaining issue, that due to the existing design of the framework it is impossible to avoid having a small bias in the addition related to the normalization. The effect is below 0.1 % for typical data sets.