### PR TITLE
Fix: fix build error on Centos

### DIFF
--- a/DreamFunction/CMakeLists.txt
+++ b/DreamFunction/CMakeLists.txt
@@ -19,14 +19,14 @@ SET(KITTY_PATH "${CMAKE_SOURCE_DIR}/GentleKitty")#where are all CATS related .h 
 SET(FORGIVEN_PATH "${CMAKE_SOURCE_DIR}/ForgivingQA")#where are all CATS related .h files
 SET(GAMI_PATH "${CMAKE_SOURCE_DIR}/FemtoGami")#where are all CATS related .h files
 SET(SYSTEMATIC_PATH "${CMAKE_SOURCE_DIR}/Systematics")#where are all CATS related .h files
-SET(ROOFOLD "$ENV{ROOUNFOLD_ROOT}")#where are all CATS related .h files
+SET(ROOFOLD_INCLUDE "$ENV{ROOUNFOLD_ROOT}/include")#where are all CATS related .h files
 
 include_directories(${KITTY_PATH})
 include_directories(${FORGIVEN_PATH})
 include_directories(${GAMI_PATH})
 include_directories(${SYSTEMATIC_PATH})
 include_directories(${CATS_INCLUDE})
-include_directories("${ROOFOLD}")
+include_directories(${ROOFOLD_INCLUDE})
 include_directories(${PROJECT_SOURCE_DIR})
 
 set(SRCS

--- a/FemtoGami/CMakeLists.txt
+++ b/FemtoGami/CMakeLists.txt
@@ -20,9 +20,9 @@ include(${ROOT_USE_FILE})
 SET(CATS_INCLUDE "$ENV{CATS}/include")#where are all CATS related .h files
 SET(CATS_LIB "$ENV{CATS}/lib")#where are the CATS related .a files
 
-SET(ROOFOLD "$ENV{ROOUNFOLD_ROOT}")#where are all CATS related .h files
+SET(ROOFOLD_INCLUDE "$ENV{ROOUNFOLD_ROOT}/include")#where are all CATS related .h files
 
-SET(ROOFOLD_LIB "$ENV{ROOUNFOLD_ROOT}")#where are the CATS related .a files
+SET(ROOFOLD_LIB "$ENV{ROOUNFOLD_ROOT}/lib")#where are the CATS related .a files
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${binFolder}/FemtoGami)
 include_directories(${CMAKE_SOURCE_DIR} ${PROJECT_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/src ${ROOT_INCLUDE_DIRS})
@@ -38,7 +38,7 @@ include_directories(${DREAM_PATH})
 include_directories(${FORGIVEN_PATH})
 include_directories(${SYSTEMATIC_PATH})
 include_directories(${CATS_INCLUDE})
-include_directories("${ROOFOLD}")
+include_directories(${ROOFOLD_INCLUDE})
 include_directories(${PROJECT_SOURCE_DIR})
 
 set(SRCS
@@ -55,7 +55,7 @@ set(HEADERS
   
 add_library(femtoGami STATIC ${SRCS})
 set_target_properties(femtoGami PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
-target_link_libraries(femtoGami tidyCATS DreamFunctions ForgivingFnct -L${ROOFOLD} RooUnfold)
+target_link_libraries(femtoGami tidyCATS DreamFunctions ForgivingFnct -L${ROOFOLD_LIB} RooUnfold)
 
 add_executable(XiGami ${PROJECT_SOURCE_DIR}/Scripts/XiGami.C)
 target_link_libraries(XiGami femtoGami)

--- a/FemtoGami/MomentumGami.cxx
+++ b/FemtoGami/MomentumGami.cxx
@@ -151,11 +151,11 @@ void MomentumGami::SetResolution(TH2F* resoMatrix, float UnitConversion) {
         }
       }
     }
-    TH2D* responsematrix = fResponseDefault->HresponseNoOverflow();
+    TH2D* responsematrix = (TH2D*)fResponseDefault->HresponseNoOverflow();
     responsematrix->SetName(TString::Format("%sRespMatrix", "").Data());
-    TH2D* responsematrixUp = fResponseUpper->HresponseNoOverflow();
+    TH2D* responsematrixUp = (TH2D*)fResponseUpper->HresponseNoOverflow();
     responsematrixUp->SetName(TString::Format("%sRespMatrixUp", "").Data());
-    TH2D* responsematrixLow = fResponseLower->HresponseNoOverflow();
+    TH2D* responsematrixLow = (TH2D*)fResponseLower->HresponseNoOverflow();
     responsematrixLow->SetName(TString::Format("%sRespMatrixLow", "").Data());
     fQAList->Add(responsematrix);
     fQAList->Add(responsematrixUp);
@@ -357,17 +357,17 @@ TH1F* MomentumGami::UnfoldviaRooResp(TH1F* InputDist, double Rescaling) {
   if (fHowToUnfold == kBayes) {
     std::cout <<" Unfolding using bayes \n ";
     RooUnfoldBayes unfolderer(resp[fResp], InputDist, fIter);
-    unfoldedHist = (TH1F*) unfolderer.Hreco();  //RooUnfold::kCovToy
+    unfoldedHist = (TH1F*) unfolderer.Hunfold();  //RooUnfold::kCovToy
     unfolderer.Print();
   } else if (fHowToUnfold == kB2B) {
     std::cout <<" Unfolding using B2B \n ";
     RooUnfoldBinByBin unfolderer(resp[fResp], InputDist);
-    unfoldedHist = (TH1F*)  unfolderer.Hreco();  //RooUnfold::kCovToy
+    unfoldedHist = (TH1F*)  unfolderer.Hunfold();  //RooUnfold::kCovToy
     unfolderer.Print();
   } else if (fHowToUnfold == kIDS) {
     std::cout <<" Unfolding using IDS \n ";
     RooUnfoldIds unfolderer(resp[fResp], InputDist, fIter);
-    unfoldedHist = (TH1F*) unfolderer.Hreco();  //RooUnfold::kCovToy
+    unfoldedHist = (TH1F*) unfolderer.Hunfold();  //RooUnfold::kCovToy
     unfolderer.Print();
   } else {
     Error("MomentumGami::UnfoldviaRooResp","This should not happen \n");

--- a/GentleKitty/CMakeLists.txt
+++ b/GentleKitty/CMakeLists.txt
@@ -21,7 +21,7 @@ SET(DREAM_PATH "${CMAKE_SOURCE_DIR}/DreamFunction")#where are all CATS related .
 SET(DREAM_LIB_PATH "${CMAKE_CURRENT_BINARY_DIR}/../DreamFunction")
 SET(FORGIVEN_PATH "${CMAKE_SOURCE_DIR}/ForgivingQA")#where are all CATS related .h files
 SET(GAMI_PATH "${CMAKE_SOURCE_DIR}/FemtoGami")#where are all CATS related .h files
-SET(ROOFOLD "$ENV{ROOUNFOLD_ROOT}")#where are all CATS related .h files
+SET(ROOFOLD_INCLUDE "$ENV{ROOUNFOLD_ROOT}/include")#where are all CATS related .h files
 
 set(
     CMAKE_RUNTIME_OUTPUT_DIRECTORY
@@ -34,7 +34,7 @@ list(APPEND CMAKE_PREFIX_PATH $ENV{ROOTSYS})
 set(CMAKE_MODULE_PATH $ENV{ROOTSYS}/etc/cmake)
 find_package(ROOT REQUIRED COMPONENTS MathCore RIO Hist Tree Net EG Minuit)
 include(${ROOT_USE_FILE})
-include_directories("${ROOFOLD}")
+include_directories(${ROOFOLD_INCLUDE})
 include_directories(${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/src)
 add_definitions(${ROOT_CXX_FLAGS})
 

--- a/Systematics/CMakeLists.txt
+++ b/Systematics/CMakeLists.txt
@@ -18,14 +18,14 @@ SET(KITTY_PATH "${CMAKE_SOURCE_DIR}/GentleKitty")#where are all CATS related .h 
 SET(DREAM_PATH "${CMAKE_SOURCE_DIR}/DreamFunction")#where are all CATS related .h files
 SET(FORGIVEN_PATH "${CMAKE_SOURCE_DIR}/ForgivingQA")#where are all CATS related .h files
 SET(GAMI_PATH "${CMAKE_SOURCE_DIR}/FemtoGami")#where are all CATS related .h files
-SET(ROOFOLD "$ENV{ROOUNFOLD_ROOT}")#where are all CATS related .h files
+SET(ROOFOLD_INCLUDE "$ENV{ROOUNFOLD_ROOT}/include")#where are all CATS related .h files
 
 
 include_directories(${KITTY_PATH})
 include_directories(${DREAM_PATH})
 include_directories(${FORGIVEN_PATH})
 include_directories(${GAMI_PATH})
-include_directories("${ROOFOLD}")
+include_directories(${ROOFOLD_INCLUDE})
 
 add_executable(systematicsSigma ${PROJECT_SOURCE_DIR}/EvalSigmaSystematics.C)
 target_link_libraries(systematicsSigma tidyCATS DreamFunctions ForgivingFnct)


### PR DESCRIPTION
In the CMakeLists.txt files there was no differentiation between the locations of the shared libraries and headers for RooUnfold. This is fixed with this commit by updating variables pointing to these locations.